### PR TITLE
Fix `on` in workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,8 @@ name: Build and Deploy docs
 on:
   push:
     branches:
-      - [master,main]
+      - master
+      - main
 
 jobs:
   build-docs:


### PR DESCRIPTION
## Overview
This PR aims to fix `on` call branches arguments. It expects a string but a list was given.

## Screenshot of the error
![image](https://user-images.githubusercontent.com/36472216/182026920-c5c4fadc-e3f9-4d69-99f8-d63f1d290099.png)

## Solution
Changing
```python
on:
   push:
        branches:
        - [master,main]
```
to
```python
on:
   push:
        branches:
        - master
        - main
 ```
This was causing the workflow to fail without even starting, making it difficult to understand the exact cause for failure or whether it would even fail when run.

## Notes for reviewers
You can merge this PR or amend the workflow file and dump this one.