### PR TITLE
Fixing docs workflow run

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - fix-docs
 
 jobs:
   build-docs:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - main
-      - fix-docs
 
 jobs:
   build-docs:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,4 +46,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3.6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+        publish_dir: docs/_build/html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ pyobis
 |pypi| |docs|
 
 Python client for the `OBIS API
-<https://github.com/iobis/api-docs>`__.
+<https://api.obis.org/>`__.
 
 `Source on GitHub at iobis/pyobis <https://github.com/iobis/pyobis>`__
 


### PR DESCRIPTION
## Overview
The deploy_docs workflow run was throwing some errors due to a broken link to the API docs (which didn't happen during local tests, I don't know why.) Also, there was an error being thrown while navigating into the _build/html directory after the building process, because the folder was name _build/ and workflow was trying to call build/.

This PR resolves both of these issues.