### PR TITLE
[update] Enable Array handling for `taxonid`s through a single query (#99)

### DIFF
--- a/pyobis/checklist/checklist.py
+++ b/pyobis/checklist/checklist.py
@@ -3,7 +3,13 @@
 """
 import sys
 
-from ..obisutils import OBISQueryResult, handle_arrstr, obis_baseurl, obis_GET
+from ..obisutils import (
+    OBISQueryResult,
+    handle_arrint,
+    handle_arrstr,
+    obis_baseurl,
+    obis_GET,
+)
 
 
 class ChecklistQuery(OBISQueryResult):
@@ -61,6 +67,7 @@ class ChecklistQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "checklist"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "taxonid": taxonid,
             "nodeid": nodeid,
@@ -176,6 +183,7 @@ class ChecklistQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "checklist/redlist"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "taxonid": taxonid,
             "nodeid": nodeid,
@@ -235,6 +243,7 @@ class ChecklistQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "checklist/newest"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "taxonid": taxonid,
             "nodeid": nodeid,

--- a/pyobis/dataset/dataset.py
+++ b/pyobis/dataset/dataset.py
@@ -2,7 +2,13 @@
 /dataset/ API endpoints as documented on https://api.obis.org/.
 """
 
-from ..obisutils import OBISQueryResult, handle_arrstr, obis_baseurl, obis_GET
+from ..obisutils import (
+    OBISQueryResult,
+    handle_arrint,
+    handle_arrstr,
+    obis_baseurl,
+    obis_GET,
+)
 
 
 class DatasetQuery(OBISQueryResult):
@@ -98,6 +104,7 @@ class DatasetQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "dataset"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "taxonid": taxonid,
             "nodeid": nodeid,

--- a/pyobis/obisutils.py
+++ b/pyobis/obisutils.py
@@ -80,6 +80,7 @@ def handle_arrstr(x):
         else:
             return ",".join(x)
 
+
 def handle_arrint(x):
     """Converts array arguments into comma-separated integers if applicable."""
     if x.__class__.__name__ == "NoneType":

--- a/pyobis/obisutils.py
+++ b/pyobis/obisutils.py
@@ -79,3 +79,14 @@ def handle_arrstr(x):
             return x
         else:
             return ",".join(x)
+
+def handle_arrint(x):
+    """Converts array arguments into comma-separated integers if applicable."""
+    if x.__class__.__name__ == "NoneType":
+        pass
+    else:
+        if x.__class__.__name__ == "int":
+            return x
+        else:
+            x = list(map(str, x))
+            return ",".join(x)

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -11,6 +11,7 @@ import requests
 
 from ..obisutils import (
     OBISQueryResult,
+    handle_arrint,
     handle_arrstr,
     obis_baseurl,
     obis_GET,
@@ -118,6 +119,7 @@ class OccQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "occurrence"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         args = {
             "taxonid": taxonid,
             "nodeid": nodeid,
@@ -371,6 +373,7 @@ class OccQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "occurrence/points"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "scientificname": scientificname,
             "taxonid": taxonid,
@@ -460,6 +463,7 @@ class OccQuery(OBISQueryResult):
         z = str(z) if z else ""
         OBISQueryResult.url = obis_baseurl + f"occurrence/point/{str(x)}/{str(y)}/{z}"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "scientificname": scientificname,
             "taxonid": taxonid,
@@ -551,6 +555,7 @@ class OccQuery(OBISQueryResult):
             obis_baseurl + f"occurrence/tile/{str(x)}/{str(y)}/{str(z)}"
         )
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "scientificname": scientificname,
             "taxonid": taxonid,
@@ -639,6 +644,7 @@ class OccQuery(OBISQueryResult):
         """
         OBISQueryResult.url = obis_baseurl + "occurrence/centroid"
         scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "scientificname": scientificname,
             "taxonid": taxonid,

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -282,6 +282,8 @@ class OccQuery(OBISQueryResult):
             occ.grid(1000, False)   // returns in KML format
         """
         OBISQueryResult.url = obis_baseurl + "occurrence/grid/" + str(precision)
+        scientificname = handle_arrstr(scientificname)
+        taxonid = handle_arrint(taxonid)
         OBISQueryResult.args = {
             "scientificname": scientificname,
             "taxonid": taxonid,


### PR DESCRIPTION
## Overview
This PR aims to enable array handling for `taxonid` as well. Adding support for querying multiple `taxonid`s at the same time will be crucial as well as beneficial for the package.

## Method
+ We created a separate function in the `obisutils.py` file to handle integer arrays. Since `taxonid`s are integer values, therefore we could not fit them into the existing array handling function for strings - `handle_arrstr()`. 
+ Fitting into the existing string array handling function `handle_arrstr()` would lead to unnecessary type conversion attempts and missed type checks for `taxonid` items.
+ So, we created a new `handle_arrint()` function.

Tries to resolve #99.

Thanks!