### PR TITLE
[fix] Fixing the package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     # The package metadata is specified in setup.cfg but GitHub's downstream dependency graph
     # does not work unless we put the name this here too.
     name="pyobis",
-    version = "1.3.0",
+    version="1.3.0",
     # use_scm_version={
     #     "write_to": "pyobis/_version.py",
     #     "write_to_template": '__version__ = "1.3.0"',

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,10 @@ setup(
     # The package metadata is specified in setup.cfg but GitHub's downstream dependency graph
     # does not work unless we put the name this here too.
     name="pyobis",
-    use_scm_version={
-        "write_to": "pyobis/_version.py",
-        "write_to_template": '__version__ = "{version}"',
-        "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
-    },
+    version = "1.3.0",
+    # use_scm_version={
+    #     "write_to": "pyobis/_version.py",
+    #     "write_to_template": '__version__ = "1.3.0"',
+    #     "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+    # },
 )


### PR DESCRIPTION
## Overview
I was not able to find a fix that could help us get the right package version automatically. I felt that specifying one version was the key right now, and later we can bring in the automatic versioning because apparently the next version relies on the previous version when using the `regex` string.

Resolves #116 

Thanks!