### PR TITLE
fixes #121 and fixes failing tests due to endpoint error

### DIFF
--- a/pyobis/checklist/checklist.py
+++ b/pyobis/checklist/checklist.py
@@ -170,7 +170,7 @@ def list(
         "size": 10,
     }
 
-    return ChecklistResponse(url, args, paginate=True)
+    return ChecklistResponse(url, {**args, **kwargs}, paginate=True)
 
 
 def redlist(
@@ -224,7 +224,7 @@ def redlist(
         "flags": flags,
     }
 
-    return ChecklistResponse(url, args, paginate=False)
+    return ChecklistResponse(url, {**args, **kwargs}, paginate=False)
 
 
 def newest(
@@ -278,4 +278,4 @@ def newest(
         "flags": flags,
     }
 
-    return ChecklistResponse(url, args, paginate=False)
+    return ChecklistResponse(url, {**args, **kwargs}, paginate=False)

--- a/pyobis/dataset/dataset.py
+++ b/pyobis/dataset/dataset.py
@@ -109,7 +109,7 @@ def search(
     }
 
     mapper = False
-    return DatasetResponse(url, args, mapper)
+    return DatasetResponse(url, {**args, **kwargs}, mapper)
 
 
 def get(id, **kwargs):
@@ -133,7 +133,7 @@ def get(id, **kwargs):
     mapper = True
 
     # returns a DatasetResponse object
-    return DatasetResponse(url, args, mapper)
+    return DatasetResponse(url, {**args, **kwargs}, mapper)
 
 
 class DatasetResponse:

--- a/pyobis/nodes/nodes.py
+++ b/pyobis/nodes/nodes.py
@@ -25,7 +25,7 @@ def search(id=None, **kwargs):
     args = {}
 
     # return NodesQuery Object
-    return NodesResponse(url, args, mapper)
+    return NodesResponse(url, {**args, **kwargs}, mapper)
 
 
 def activities(id=None, **kwargs):
@@ -52,7 +52,7 @@ def activities(id=None, **kwargs):
     mapper = False
 
     # return a NodesQuery object
-    return NodesResponse(url, args, mapper)
+    return NodesResponse(url, {**args, **kwargs}, mapper)
 
 
 class NodesResponse:

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -170,7 +170,7 @@ def get(id, **kwargs):
     url = obis_baseurl + "occurrence/" + str(id)
     args = {}
 
-    return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=False)
+    return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=False)
 
 
 def search(
@@ -287,7 +287,7 @@ def search(
         "size": size,
         "hasextensions": hasextensions,
     }
-    return OccResponse(url, args, isSearch=True, hasMapper=True, isKML=False)
+    return OccResponse(url, {**args,**kwargs}, isSearch=True, hasMapper=True, isKML=False)
 
 
 def grid(
@@ -366,9 +366,9 @@ def grid(
     }
     if not geojson:
         url += "/kml"
-        return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=True)
+        return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=True)
 
-    return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=False)
+    return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=False)
 
 
 def getpoints(
@@ -445,7 +445,7 @@ def getpoints(
         "exclude": exclude,
     }
 
-    return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=False)
+    return OccResponse(url, {**args, **kwargs}, isSearch=False, hasMapper=False, isKML=False)
 
 
 def point(
@@ -528,7 +528,7 @@ def point(
         "exclude": exclude,
     }
 
-    return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=False)
+    return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=False)
 
 
 def tile(
@@ -612,9 +612,9 @@ def tile(
     }
     if mvt:
         url += ".mvt"
-        return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=True)
+        return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=True)
 
-    return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=False)
+    return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=False)
 
 
 def centroid(
@@ -687,7 +687,7 @@ def centroid(
         "exclude": exclude,
     }
 
-    return OccResponse(url, args, isSearch=False, hasMapper=False, isKML=False)
+    return OccResponse(url, {**args,**kwargs}, isSearch=False, hasMapper=False, isKML=False)
 
 
 def lookup_taxon(scientificname):

--- a/pyobis/occurrences/test_occurrence.py
+++ b/pyobis/occurrences/test_occurrence.py
@@ -52,7 +52,7 @@ def test_occurrences_get():
     """
     occurrences.get - basic test for data, check type, size and other methods
     """
-    query = occurrences.get(id="00003cf7-f2fc-4c53-98a6-7d846e70f5d1")
+    query = occurrences.get(id=occurrences.search(size=1).execute()['id'].values[0])
     assert not query.data
     query.execute()
     assert "dict" == query.data.__class__.__name__

--- a/pyobis/taxa/taxa.py
+++ b/pyobis/taxa/taxa.py
@@ -66,7 +66,7 @@ def taxon(id, **kwargs):
     url = obis_baseurl + "taxon/" + str(id)
     args = {}
     # return a TaxaResponse Object
-    return TaxaResponse(url, args)
+    return TaxaResponse(url, {**args, **kwargs})
 
 
 def annotations(scientificname, **kwargs):
@@ -94,7 +94,7 @@ def annotations(scientificname, **kwargs):
     scientificname = handle_arrstr(scientificname)
     args = {"scientificname": scientificname}
     # return a TaxaResponse Object
-    return TaxaResponse(url, args)
+    return TaxaResponse(url, {**args, **kwargs})
 
 
 class TaxaResponse:


### PR DESCRIPTION
## Overview
+ fixes #121 by including `**kwargs` in resource fetching, and 
+ fixes failing tests due to 400 error at endpoint by using a trivial approach of picking the first occurrence id of all records.

## Changes Introduced
+ All module methods have been updated with `kwargs` acceptance. `args` -> `{**args, **kwargs}`
+ Change failing `occurrence.get()` test to fetch the first record's `id` in `occurrences.get(id=occurrences.search(size=1).execute()['id'].values[0])`.

Thanks!