### PR TITLE
[fix] uses `logging` instead of `print`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ python -m pip install -e .
 # test your installation
 python -m pytest
 # test and generate a coverage report
-python -m pytest -rxs --cov=pyobis tests
+python -m pytest -rxs --cov=pyobis ./pyobis --vcr-record=none
 ```
 
 ## Documentation

--- a/pyobis/checklist/checklist.py
+++ b/pyobis/checklist/checklist.py
@@ -10,6 +10,7 @@ from ..obisutils import (
     build_api_url,
     handle_arrint,
     handle_arrstr,
+    logger,
     obis_baseurl,
     obis_GET,
 )
@@ -55,17 +56,14 @@ class ChecklistResponse:
                 pass
 
             # fetch first 10 records, and print number of estimated records
-            print(f"Estimated records: {out['total']}")
-            print(
+            logger.info(f"Estimated records: {out['total']}")
+            logger.info(
                 "{}[{}{}] {}".format(
                     "Fetching: ",
                     "█" * int(len(out["results"]) * 100 / out["total"]),
                     "." * (100 - int(len(out["results"]) * 100 / out["total"])),
                     len(out["results"]),
-                ),
-                end="\r",
-                file=sys.stdout,
-                flush=True,
+                )
             )
             # now paginate until the response is null
             while True:
@@ -79,7 +77,7 @@ class ChecklistResponse:
                     break
                 out["results"] += res["results"]
                 # print the progress bar
-                print(
+                logger.info(
                     "{}[{}{}] {}".format(
                         "Fetching: ",
                         "█" * int(len(out["results"]) * 100 / out["total"]),
@@ -94,7 +92,7 @@ class ChecklistResponse:
                 # continue to fetch next 5000 records
                 i += 5000
             # print actual number of fetched records
-            print(f"\nFetched {len(out['results'])} records.")
+            logger.info(f"\nFetched {len(out['results'])} records.")
         else:
             out = obis_GET(
                 self.__url,

--- a/pyobis/checklist/checklist.py
+++ b/pyobis/checklist/checklist.py
@@ -63,7 +63,7 @@ class ChecklistResponse:
                     "█" * int(len(out["results"]) * 100 / out["total"]),
                     "." * (100 - int(len(out["results"]) * 100 / out["total"])),
                     len(out["results"]),
-                )
+                ),
             )
             # now paginate until the response is null
             while True:

--- a/pyobis/obisutils.py
+++ b/pyobis/obisutils.py
@@ -18,6 +18,7 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S',
 )
 
+
 class NoResultException(Exception):
     """
     Thrown when query returns no results.

--- a/pyobis/obisutils.py
+++ b/pyobis/obisutils.py
@@ -2,12 +2,21 @@
 Utility functions for internal use across various modules.
 """
 
+import logging
 from urllib.parse import urlencode
 
 import requests
 
 obis_baseurl = "https://api.obis.org/v3/"
 
+# export logger, and setup basic configurations
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    encoding='utf-8', 
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
 
 class NoResultException(Exception):
     """

--- a/pyobis/obisutils.py
+++ b/pyobis/obisutils.py
@@ -12,10 +12,10 @@ obis_baseurl = "https://api.obis.org/v3/"
 # export logger, and setup basic configurations
 logger = logging.getLogger(__name__)
 logging.basicConfig(
-    encoding='utf-8', 
+    encoding="utf-8",
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -3,7 +3,6 @@
 """
 
 import json
-import sys
 import warnings
 from time import time
 from urllib.parse import urlencode
@@ -117,10 +116,13 @@ class OccResponse:
                     break
                 self.__args["size"] = 10000
                 logger.info(
-                    f"Fetching: "
-                    f"[{"\u2588" * int((i - 1) * 100 / size)}"
-                    f"{"." * (100 - int((i + 1) * 100 / size))}]"
-                    f" {i}/{size}"
+                    "{}[{}{}] {}/{}".format(
+                        "Fetching: ",
+                        "█" * int((i - 1) * 100 / size),
+                        "." * (100 - int((i + 1) * 100 / size)),
+                        i,
+                        size,
+                    )
                 )
                 res = obis_GET(
                     self.__url,

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -118,7 +118,7 @@ class OccResponse:
                 self.__args["size"] = 10000
                 logger.info(
                     f"Fetching: "
-                    f"[{"█" * int((i - 1) * 100 / size)}"
+                    f"[{"\u2588" * int((i - 1) * 100 / size)}"
                     f"{"." * (100 - int((i + 1) * 100 / size))}]"
                     f" {i}/{size}"
                 )
@@ -142,7 +142,7 @@ class OccResponse:
             # we have already fetched records as a set of 5000 records each time,
             # now we need to get remaining records from the total
             logger.info(
-                "{}[{}{}] {}/{}".format("Fetching: ", "█" * 100, "." * 0, size, size),
+                "{}[{}{}] {}/{}".format("Fetching: ", "\u2588" * 100, "." * 0, size, size),
             )
             res = obis_GET(
                 self.__url,
@@ -154,7 +154,7 @@ class OccResponse:
                 [outdf.infer_objects(), pd.DataFrame(res["results"]).infer_objects()],
                 ignore_index=True,
             )
-            logger.info(f"\nFetched {size} records.")
+            logger.info(f"Fetched {size} records.")
 
             if mof and self.__total_records > 0:
                 mofNormalized = pd.json_normalize(

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -16,6 +16,7 @@ from ..obisutils import (
     handle_arrint,
     handle_arrstr,
     obis_baseurl,
+    logger,
     obis_GET,
 )
 
@@ -71,10 +72,10 @@ class OccResponse:
                 # the total time can be estimated easily although this might not be accurate
                 # for larger than 100k records, because the network download takes
                 # even smaller fraction of the total round-trip time
-                print(
-                    f"{self.__total_records} to be fetched. Estimated time = ",
-                    (ending_time - starting_time) * 0.995,
-                    f" {(ending_time - starting_time) * 0.005 * self.__total_records:.0f} ",
+                logger.info(
+                    f"{self.__total_records} to be fetched. Estimated time ="
+                    f"{(ending_time - starting_time) * 0.995}"
+                    f"{(ending_time - starting_time) * 0.005 * self.__total_records:.0f} "
                     "seconds",
                 )
 
@@ -115,17 +116,11 @@ class OccResponse:
                 if "id" not in outdf.columns:
                     break
                 self.__args["size"] = 10000
-                print(
-                    "{}[{}{}] {}/{}".format(
-                        "Fetching: ",
-                        "█" * int((i - 1) * 100 / size),
-                        "." * (100 - int((i + 1) * 100 / size)),
-                        i,
-                        size,
-                    ),
-                    end="\r",
-                    file=sys.stdout,
-                    flush=True,
+                logger.info(
+                    f"Fetching: "
+                    f"[{"█" * int((i - 1) * 100 / size)}"
+                    f"{"." * (100 - int((i + 1) * 100 / size))}]"
+                    f" {i}/{size}"
                 )
                 res = obis_GET(
                     self.__url,
@@ -146,11 +141,8 @@ class OccResponse:
             self.__args["size"] = size % 10000
             # we have already fetched records as a set of 5000 records each time,
             # now we need to get remaining records from the total
-            print(
+            logger.info(
                 "{}[{}{}] {}/{}".format("Fetching: ", "█" * 100, "." * 0, size, size),
-                end="\r",
-                file=sys.stdout,
-                flush=True,
             )
             res = obis_GET(
                 self.__url,
@@ -162,7 +154,7 @@ class OccResponse:
                 [outdf.infer_objects(), pd.DataFrame(res["results"]).infer_objects()],
                 ignore_index=True,
             )
-            print(f"\nFetched {size} records.")
+            logger.info(f"\nFetched {size} records.")
 
             if mof and self.__total_records > 0:
                 mofNormalized = pd.json_normalize(

--- a/pyobis/occurrences/occurrences.py
+++ b/pyobis/occurrences/occurrences.py
@@ -14,8 +14,8 @@ from ..obisutils import (
     build_api_url,
     handle_arrint,
     handle_arrstr,
-    obis_baseurl,
     logger,
+    obis_baseurl,
     obis_GET,
 )
 
@@ -122,7 +122,7 @@ class OccResponse:
                         "." * (100 - int((i + 1) * 100 / size)),
                         i,
                         size,
-                    )
+                    ),
                 )
                 res = obis_GET(
                     self.__url,
@@ -144,7 +144,13 @@ class OccResponse:
             # we have already fetched records as a set of 5000 records each time,
             # now we need to get remaining records from the total
             logger.info(
-                "{}[{}{}] {}/{}".format("Fetching: ", "\u2588" * 100, "." * 0, size, size),
+                "{}[{}{}] {}/{}".format(
+                    "Fetching: ",
+                    "\u2588" * 100,
+                    "." * 0,
+                    size,
+                    size,
+                ),
             )
             res = obis_GET(
                 self.__url,


### PR DESCRIPTION
Fixes #156. 

+ Initialises a logger object with basic configuration (ts, name, message). Changes `print` to `logging` everywhere.
+ Tiny fix for instructions around running tests in README.

Thanks.