### PR TITLE
fix: fixes #171; brings more type checks for returned data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docs](https://github.com/iobis/pyobis/actions/workflows/deploy-docs.yml/badge.svg)](https://iobis.github.ic/pyobis)
 [![tests](https://github.com/iobis/pyobis/actions/workflows/tests.yml/badge.svg)](https://github.com/iobis/pyobis/actions/workflows/tests.yml)
 
-Python client for the `OBIS API(https://api.obis.org/).
+Python client for the [OBIS API](https://api.obis.org/).
 
 [Source on GitHub at iobis/pyobis](https://github.com/iobis/pyobis)
 

--- a/pyobis/occurrences/test_occurrence.py
+++ b/pyobis/occurrences/test_occurrence.py
@@ -15,8 +15,10 @@ def test_occurrences_search():
     query = occurrences.search(scientificname="Mola mola", size=size)
     assert not query.data  # the data is none after query building but before executing
     query.execute()
-    assert size == len(query.data)
-    assert "Mola mola" == query.data.scientificName[0]
+    assert "dict" == query.data.__class__.__name__
+    assert 2 == len(query.data)
+    assert size == len(query.to_pandas())
+    assert "Mola mola" == query.to_pandas().scientificName[0]
 
 
 @pytest.mark.vcr()
@@ -32,7 +34,7 @@ def test_occurrence_search_mof():
     )
     assert not query.data
     query.execute()
-    assert "Abra alba" == query.data.scientificName[0]
+    assert "Abra alba" == query.to_pandas().scientificName[0]
     assert requests.get(query.api_url).status_code == 200
     assert requests.get(query.mapper_url).status_code == 200
 
@@ -83,6 +85,13 @@ def test_occurrences_grid():
     assert requests.get(query.api_url).status_code == 200
     assert not query.mapper_url
 
+    # check for KML formats that to_pandas function is not implemented
+    with pytest.raises(
+        NotImplementedError,
+        match="to_pandas method is not yet available for these query types.",
+    ):
+        query.to_pandas()
+
 
 @pytest.mark.vcr()
 def test_occurrences_getpoints():
@@ -128,6 +137,14 @@ def test_occurrences_tile():
     query = occurrences.tile(x=1.77, y=52.26, z=0.5, mvt=1, scientificname="Mola mola")
     query.execute()
     assert requests.get(query.api_url).status_code == 200
+
+    # check for MVT formats that to_pandas function is not implemented
+    with pytest.raises(
+        NotImplementedError,
+        match="to_pandas method is not yet available for these query types.",
+    ):
+        query.to_pandas()
+
     query = occurrences.tile(x=1.77, y=52.26, z=0.5, mvt=0, scientificname="Mola mola")
     query.execute()
     assert requests.get(query.api_url).status_code == 200


### PR DESCRIPTION
## Overview
* fixes #171; there were some inconsistencies with data returned by `search` queries on `occurrences`. For backwards compatibiity, `execute` still returns a `DataFrame` object, but sets data in `OccResponse` as `dict({total: int, results: DataFrame/dict})`. This fixes failing `to_pandas` method.
* raise a `NotImplementedError` on calling `to_pandas` for non-supported data types
* Resolves some `FutureWarning` while concatenating DataFrame during `search`. NA value columns while being merged with non-NA ones was throwing this warning. We do the merges while paginating large queries as API supports only 10k records at a time. So, we merge these chunks into one. Resolution was to skip merge during the first one (when the original results DataFrame is empty).
* Add corresponding unittests.
* Tiny typo on README that introduced an annoying tilda (\`) on the link. Possibly came up during conversion from `rst` -> `md`.

Thanks.