### PR TITLE
add missing requests-cache dependency

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.5.1 (2025-06-23)
+----------------------
+- MAJOR:
+    - none
+- MINOR:
+    - none
+- PATCH:
+    - added missing requests-cache dependency
+
 1.5.0 (2025-06-20)
 ----------------------
 - MAJOR:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,5 +29,6 @@ classifiers =
 install_requires =
     requests>2.7
     pandas
+    requests-cache==1.2.0
 python_requires = >=3.7
 packages = find:


### PR DESCRIPTION
closes #185. Creates a new patch version to add missing dependency (now `v1.5.1`).